### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/bff-gateway/src/controllers/resumes.controller.ts
+++ b/bff-gateway/src/controllers/resumes.controller.ts
@@ -19,6 +19,13 @@ const generateSchema = z.object({
   outputFormats: z.array(z.enum(['pdf', 'docx', 'html'])).optional(),
 });
 
+const generateParamsSchema = z.object({
+  resumeId: z
+    .string()
+    .min(1, 'resumeId is required')
+    .regex(/^[A-Za-z0-9_-]+$/, 'resumeId contains invalid characters'),
+});
+
 type GenerateParams = { resumeId: string };
 
 /** Handles POST /resumes/ingest - triggers a resume ingest job. */
@@ -36,10 +43,15 @@ export async function generate(
   request: FastifyRequest<{ Params: GenerateParams }>,
   reply: FastifyReply,
 ): Promise<void> {
-  const resumeId = request.params.resumeId;
-  if (!resumeId) {
-    logger.warn({ correlationId: request.correlationId }, 'generate: resumeId missing from params');
-    void reply.code(400).send(formatError('VALIDATION_ERROR', 'resumeId is required'));
+  let resumeId: string;
+  try {
+    ({ resumeId } = generateParamsSchema.parse(request.params));
+  } catch (err) {
+    logger.warn(
+      { correlationId: request.correlationId, error: err },
+      'generate: invalid resumeId in params',
+    );
+    void reply.code(400).send(formatError('VALIDATION_ERROR', 'Invalid resumeId'));
     return;
   }
   logger.debug({ correlationId: request.correlationId, resumeId }, 'generate: validating request body');


### PR DESCRIPTION
Potential fix for [https://github.com/RichardRosenblat/elastic-resume-base/security/code-scanning/3](https://github.com/RichardRosenblat/elastic-resume-base/security/code-scanning/3)

General approach: Validate and strongly constrain the user-supplied `resumeId` before using it to construct the request path. Ensure it matches an expected safe pattern (such as a UUID or restricted alphanumeric token) and reject any request where it does not. This prevents path traversal or other unexpected characters from influencing the downstream URL, and it makes the taint analysis see a sanitized value.

Best concrete fix with minimal behavior change:
- In `bff-gateway/src/controllers/resumes.controller.ts`, introduce a Zod schema for the route params (`GenerateParams`) so that `resumeId` is validated before being passed to `generateResume`.
- Constrain `resumeId` to a sane pattern. A practical and safe choice without changing semantics too much is to require non-empty, trimmed strings with a restricted character set, e.g. `/^[A-Za-z0-9_-]+$/`. This prevents slashes and `..` sequences (no path traversal), and also avoids spaces and other problematic characters.
- Parse and validate `request.params` with this schema at the beginning of the `generate` handler. If validation fails, return a 400 error as you already do for missing `resumeId`.
- After validation, use the sanitized `resumeId` (from the schema) when calling `generateResume`, keeping the rest of the logic unchanged.

Concretely:
- In `resumes.controller.ts`, add a new `generateParamsSchema` using `z.object({ resumeId: ... })`.
- Replace the direct `const resumeId = request.params.resumeId;` logic with `const { resumeId } = generateParamsSchema.parse(request.params);`.
- Keep using `generateResume(resumeId, body);` as before.

No changes are required in `fileGeneratorClient.ts` because once `resumeId` is validated in the controller, the value arriving there is guaranteed to be safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
