### PR TITLE
feat: add depth parameter to config file search for improved flexibility

### DIFF
--- a/shared/Toolbox/v1/toolbox_py/toolbox_py/config.py
+++ b/shared/Toolbox/v1/toolbox_py/toolbox_py/config.py
@@ -22,15 +22,18 @@ except ImportError:  # pragma: no cover - handled gracefully when dependency mis
     _yaml = None  # type: ignore[assignment]
 
 
-def _config_file_candidates() -> list[Path]:
+def _config_file_candidates(depth: int = 2) -> list[Path]:
     """Return candidate YAML config paths in priority order.
 
     Search order:
     1. Path in the ``CONFIG_FILE`` environment variable (explicit override).
-    2. ``configs.yaml`` in the current working directory.
-    3. ``config.yaml`` in the current working directory.
-    4. ``configs.yaml`` one directory above the current working directory.
-    5. ``config.yaml`` one directory above the current working directory.
+    2. ``configs.yaml`` / ``config.yaml`` in the current working directory.
+    3. ``configs.yaml`` / ``config.yaml`` in each parent directory up to
+       ``depth`` levels above the current working directory.
+
+    Args:
+        depth: Number of parent directories to traverse upwards when searching
+            for a config file (default ``2``).
     """
     cwd = Path.cwd()
 
@@ -39,14 +42,12 @@ def _config_file_candidates() -> list[Path]:
     if explicit:
         candidates.append(Path(explicit))
 
-    candidates.extend(
-        [
-            cwd / "configs.yaml",
-            cwd / "config.yaml",
-            cwd.parent / "configs.yaml",
-            cwd.parent / "config.yaml",
-        ]
-    )
+    candidates.extend([cwd / "configs.yaml", cwd / "config.yaml"])
+
+    current = cwd
+    for _ in range(depth):
+        current = current.parent
+        candidates.extend([current / "configs.yaml", current / "config.yaml"])
 
     # De-duplicate while preserving order.
     seen: set[Path] = set()
@@ -58,7 +59,7 @@ def _config_file_candidates() -> list[Path]:
     return unique
 
 
-def load_config_yaml(service_name: str) -> None:
+def load_config_yaml(service_name: str, depth: int = 2) -> None:
     """Seed ``os.environ`` from the monorepo YAML config file.
 
     Loads the first config file found in the candidate search order and merges
@@ -75,14 +76,15 @@ def load_config_yaml(service_name: str) -> None:
     Search order:
 
     1. Path in the ``CONFIG_FILE`` environment variable (explicit override).
-    2. ``configs.yaml`` in the current working directory.
-    3. ``config.yaml`` in the current working directory.
-    4. ``configs.yaml`` one directory above the current working directory.
-    5. ``config.yaml`` one directory above the current working directory.
+    2. ``configs.yaml`` / ``config.yaml`` in the current working directory.
+    3. ``configs.yaml`` / ``config.yaml`` in each parent directory up to
+       ``depth`` levels above the current working directory.
 
     Args:
         service_name: Key under ``systems.<service_name>`` in the YAML config
             (e.g. ``"document-reader"``).
+        depth: Number of parent directories to traverse upwards when searching
+            for a config file (default ``2``).
 
     Example::
 
@@ -94,7 +96,7 @@ def load_config_yaml(service_name: str) -> None:
     if _yaml is None:
         return
 
-    config_path = next((p for p in _config_file_candidates() if p.exists()), None)
+    config_path = next((p for p in _config_file_candidates(depth) if p.exists()), None)
     if config_path is None:
         return
 


### PR DESCRIPTION
This pull request updates the configuration file discovery logic in `toolbox_py/config.py` to make it more flexible and configurable. The main improvement is that the search for `configs.yaml` or `config.yaml` files now traverses up multiple parent directories, with the number of levels controlled by a new `depth` parameter (defaulting to 2). This allows for easier configuration management in nested directory structures.

**Config file discovery enhancements:**

* The `_config_file_candidates` function now accepts a `depth` parameter, allowing the search for config files to traverse up a specified number of parent directories instead of being limited to just one level above the current working directory. [[1]](diffhunk://#diff-e4272e59fb5b482217efb72373bf3a82a3e151c2b29f1420eac3f919a02bb087L25-R36) [[2]](diffhunk://#diff-e4272e59fb5b482217efb72373bf3a82a3e151c2b29f1420eac3f919a02bb087L42-R50)
* The search order in both the code and docstrings has been updated to reflect the new logic: after checking the environment variable, the function searches for `configs.yaml` and `config.yaml` in the current working directory and then in each parent directory up to the specified depth.
* The `load_config_yaml` function now accepts a `depth` parameter, which is passed through to `_config_file_candidates`, making the config file search depth customizable by callers. [[1]](diffhunk://#diff-e4272e59fb5b482217efb72373bf3a82a3e151c2b29f1420eac3f919a02bb087L61-R62) [[2]](diffhunk://#diff-e4272e59fb5b482217efb72373bf3a82a3e151c2b29f1420eac3f919a02bb087L97-R99)## Description
