### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/apps/gateway-api/src/routes/index.ts
+++ b/apps/gateway-api/src/routes/index.ts
@@ -33,6 +33,7 @@ const routes: FastifyPluginAsync = async (app) => {
       // before the expensive Firebase token-verification and users-api calls run.
       // This prevents denial-of-service attacks via token flooding.
       await api.register(rateLimit, {
+        global: true,
         max: config.apiV1RateLimitMax,
         timeWindow: config.apiV1RateLimitTimeWindow,
         errorResponseBuilder: buildRateLimitErrorResponseBuilder('API v1'),


### PR DESCRIPTION
Potential fix for [https://github.com/RichardRosenblat/elastic-resume-base/security/code-scanning/6](https://github.com/RichardRosenblat/elastic-resume-base/security/code-scanning/6)

General fix: ensure authorization logic is always preceded by explicit rate limiting in the same request path/scope, using framework-native middleware/hook configuration that static analysis can recognize.

Best fix in this file: keep `@fastify/rate-limit` registration, and make it explicit that all routes in this encapsulated `/api/v1` scope are rate-limited by default via `global: true`. This preserves functionality while making coverage clearer for both humans and tooling.

Change region:
- `apps/gateway-api/src/routes/index.ts`
- In the `await api.register(rateLimit, { ... })` options object (around lines 35–39), add `global: true`.

No new methods needed, no import changes needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
