### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/apps/users-api/src/routes/users.ts
+++ b/apps/users-api/src/routes/users.ts
@@ -173,6 +173,12 @@ const usersPlugin: FastifyPluginAsync = async (app) => {
   // ── Unauthenticated Routes ──────────────────────────────────────────────────
 
   app.post('/authorize', {
+    config: {
+      rateLimit: {
+        max: 20,
+        timeWindow: '1 minute',
+      },
+    },
     schema: {
       tags: ['Users'],
       summary: 'Authorize a user (Gateway API login flow)',


### PR DESCRIPTION
Potential fix for [https://github.com/RichardRosenblat/elastic-resume-base/security/code-scanning/7](https://github.com/RichardRosenblat/elastic-resume-base/security/code-scanning/7)

General fix: apply rate-limiting middleware/config to endpoints that perform authorization and/or database work, especially unauthenticated routes. In Fastify, the common approach is using `@fastify/rate-limit` and attaching route-level limits via `config.rateLimit`.

Best targeted fix in this file: add a route-level rate-limit configuration to the `/authorize` route options object (the one passed to `app.post('/authorize', { ... }, authorizeHandler)`). This preserves existing behavior while constraining request volume. A practical default is a short window and modest cap (for example 20 requests/minute per client), which can be tuned later.

File/region to change:
- `apps/users-api/src/routes/users.ts`
- Inside the `/authorize` route options object, add:
  - `config: { rateLimit: { max: 20, timeWindow: '1 minute' } }`

No import changes are required for this file-level edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
