### PR TITLE
add ingestor service translations for English, Spanish, and Portuguese

### DIFF
--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -212,6 +212,11 @@
     "loading": "Checking service health...",
     "unavailable": "Status Unavailable — could not reach the health endpoint.",
     "services": {
+      "ingestor": {
+        "name": "Resume Ingestor",
+        "description": "Handles the ingestion of resumes from various sources and formats.",
+        "impact": "Ingesting new resumes will not be available, but existing resumes will still be searchable."
+      },
       "usersApi": {
         "name": "User Management",
         "description": "Manages user accounts, roles, and permissions.",

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -212,6 +212,11 @@
 		"loading": "Verificando el estado de los servicios...",
 		"unavailable": "Estado No Disponible — no se pudo alcanzar el endpoint de salud.",
 		"services": {
+			"ingestor": {
+				"name": "Ingestor de Currículums",
+				"description": "Gestiona la ingestión de currículums desde varias fuentes y formatos.",
+				"impact": "La ingestión de nuevos currículums no estará disponible, pero los currículums existentes aún serán buscables."
+			},
 			"usersApi": {
 				"name": "Gestión de Usuarios",
 				"description": "Administra cuentas de usuario, roles y permisos.",

--- a/apps/frontend/src/i18n/locales/pt-BR.json
+++ b/apps/frontend/src/i18n/locales/pt-BR.json
@@ -211,6 +211,11 @@
 		"loading": "Verificando a integridade dos serviços...",
 		"unavailable": "Status Indisponível — não foi possível acessar o endpoint de saúde.",
 		"services": {
+			"ingestor": {
+				"name": "Ingestor de Currículos",
+				"description": "Gerencia a ingestão de currículos de várias fontes e formatos.",
+				"impact": "A ingestão de novos currículos não estará disponível, mas os currículos existentes ainda estarão pesquisáveis."
+			},
 			"usersApi": {
 				"name": "Gestão de Usuários",
 				"description": "Gerencia contas de usuário, funções e permissões.",


### PR DESCRIPTION
feat(i18n): add ingestor service translations for English, Spanish, and Portuguese

## Description

Added i18n translations for the ingestor service in the system status page for English, Spanish, and Portuguese locales. This includes the service name, description, and impact message when the service is unavailable.

## Type of Change

- [x] `feat` — New feature

## Affected Services / Scope

- **Services affected:** frontend (system status page)
- **Breaking changes:** no

## Checklist

- [x] My code follows the [coding standards](../documentation/coding-standards/) for the relevant language.
- [x] I have added or updated tests for my changes.
- [x] All existing tests pass locally.
- [x] I have updated relevant documentation if needed.
- [x] No secrets, credentials, or PII have been committed.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have rebased my branch on `main` and resolved all conflicts.
